### PR TITLE
Feat: order list SabangAPI(XML) to db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 *.xlsx
 *.xml
 */__pycache__/*
+logs/*

--- a/controller/order_list.py
+++ b/controller/order_list.py
@@ -76,6 +76,20 @@ def get_order_status():
     return order_status
 
 
+def select_order_save_method() -> bool:
+    print("\n주문 데이터 저장 방식을 선택하세요:")
+    print("1. DB에 저장 (권장)")
+    print("2. JSON 파일로 저장")
+    method = input("선택하세요 (1 또는 2): ").strip()
+    if method == "1":
+        return True
+    elif method == "2":
+        return False
+    else:
+        print("잘못된 선택입니다. 기본값(JSON 저장)으로 진행합니다.")
+        return False
+
+
 def fetch_order_list():
     xml_base_path = Path("./files/xml")
     try:
@@ -94,6 +108,7 @@ def fetch_order_list():
         print("2. XML 내용을 직접 업로드 후 URL로 호출")
         print("3. XML URL을 직접 입력하여 호출")
         choice = input("\n선택하세요 (1, 2 또는 3): ").strip()
+        to_db = select_order_save_method()
         if choice == "1":
             # 1. XML 생성 및 파일로 저장
             xml_content = fetcher.create_request_xml()
@@ -107,7 +122,7 @@ def fetch_order_list():
             print(f"파일 서버에 업로드된 XML 파일 이름: {object_name}")
             xml_url = get_file_server_url(object_name)
             print(f"파일 서버에 업로드된 XML URL: {xml_url}")
-            order_list = fetcher.get_order_list_via_url(xml_url)
+            result = fetcher.get_order_list_via_url(xml_url, to_db=to_db)
         elif choice == "2":
             # 2. XML 내용을 직접 파일 서버에 업로드
             xml_content = fetcher.create_request_xml()
@@ -118,18 +133,22 @@ def fetch_order_list():
             print(f"파일 서버에 업로드된 XML 파일 이름: {object_name}")
             xml_url = get_file_server_url(object_name)
             print(f"파일 서버에 업로드된 XML URL: {xml_url}")
-            order_list = fetcher.get_order_list_via_url(xml_url)
+            result = fetcher.get_order_list_via_url(xml_url, to_db=to_db)
         elif choice == "3":
             xml_url = input("\nXML 파일의 URL을 입력하세요 (예: http://www.abc.co.kr/aa.xml): ").strip()
             if not xml_url:
                 print("유효한 XML URL을 입력해주세요.")
                 return
-            order_list = fetcher.get_order_list_via_url(xml_url)
-            print(f"XML URL 요청 결과: {order_list}")
+            result = fetcher.get_order_list_via_url(xml_url, to_db=to_db)
+            if not to_db:
+                print(f"XML URL 요청 결과: {result}")
         else:
             print("잘못된 선택입니다.")
             return
-        print("성공적으로 저장되었습니다. (경로: ./json/order_list.json)")
+        if to_db:
+            print("성공적으로 DB에 저장되었습니다.")
+        else:
+            print("성공적으로 저장되었습니다. (경로: ./json/order_list.json)")
     except ValueError as e:
         print(f"\n환경변수를 확인해주세요: {e}")
         print("- SABANG_COMPANY_ID: 사방넷 로그인 아이디")

--- a/models/receive_order/receive_order.py
+++ b/models/receive_order/receive_order.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from datetime import datetime
 
 from sqlalchemy import (
-    TIMESTAMP, Date, Integer, Numeric, String, Text, text
+    TIMESTAMP, Date, Integer, Numeric, String, Text, text, BigInteger
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -98,7 +98,7 @@ class ReceiveOrder(Base):
 
     # 기타 처리 정보
     jung_chk_yn: Mapped[str | None] = mapped_column(String(2))
-    mall_order_seq: Mapped[int | None] = mapped_column(Integer)
+    mall_order_seq: Mapped[int | None] = mapped_column(BigInteger)
     mall_order_id: Mapped[str | None] = mapped_column(String(100))
     etc_field3: Mapped[str | None] = mapped_column(Text)
     ord_field2: Mapped[str | None] = mapped_column(String(10))

--- a/models/receive_order/receive_order.py
+++ b/models/receive_order/receive_order.py
@@ -79,12 +79,12 @@ class ReceiveOrder(Base):
     p_sku_value: Mapped[str | None] = mapped_column(Text)
     product_name: Mapped[str | None] = mapped_column(Text)
     sku_value: Mapped[str | None] = mapped_column(Text)
-    compayny_goods_cd: Mapped[str | None] = mapped_column(String(100))
+    compayny_goods_cd: Mapped[str | None] = mapped_column(String(255))
     sku_alias: Mapped[str | None] = mapped_column(String(200))
     goods_nm_pr: Mapped[str | None] = mapped_column(Text)
-    goods_keyword: Mapped[str | None] = mapped_column(String(200))
-    model_no: Mapped[str | None] = mapped_column(String(100))
-    model_name: Mapped[str | None] = mapped_column(String(200))
+    goods_keyword: Mapped[str | None] = mapped_column(String(255))
+    model_no: Mapped[str | None] = mapped_column(String(255))
+    model_name: Mapped[str | None] = mapped_column(String(255))
     barcode: Mapped[str | None] = mapped_column(String(100))
 
     # 수량 및 구분 정보

--- a/services/order_list_fetch.py
+++ b/services/order_list_fetch.py
@@ -2,6 +2,7 @@ import os
 import requests
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from datetime import date
 from typing import List, Dict
 from urllib.parse import urljoin
 import logging
@@ -9,9 +10,13 @@ import json
 from pathlib import Path
 import re
 import hashlib
+from decimal import Decimal
+from utils.log_utils import write_log
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
+
+logging.getLogger("sqlalchemy.engine").setLevel(logging.ERROR)
 
 SABANG_COMPANY_ID = os.getenv('SABANG_COMPANY_ID', None)
 SABANG_AUTH_KEY = os.getenv('SABANG_AUTH_KEY', None)
@@ -92,7 +97,7 @@ class OrderListFetchService:
                         order_detail[elem_tag] = elem_text
                 order_detail["RECEIVE_DT"] = datetime.now().strftime('%Y%m%d%H%M%S')
                 order_list.append(order_detail)
-            logger.info(f"총 {len(order_list)}개의 주문을 수집했습니다.")
+            logger.error(f"총 {len(order_list)}개의 주문을 수집했습니다.")
             json_dir = Path("./files/json")
             json_dir.mkdir(exist_ok=True)
             json_path = json_dir / "order_list.json"
@@ -113,6 +118,9 @@ class OrderListFetchService:
         """
         from repository.create_receive_order import CreateReceiveOrder
         from models.receive_order.receive_order import ReceiveOrder
+        from decimal import Decimal
+        import re
+        from datetime import datetime, date
 
         MASKING_RULES = {
             'USER_NAME': 'name',
@@ -127,22 +135,62 @@ class OrderListFetchService:
             'MALL_ORDER_ID': 'id',
             'MALL_USER_ID': 'user_id'
         }
+
+        decimal_fields = [
+            'total_cost', 'pay_cost', 'sale_cost', 'mall_won_cost', 'won_cost', 'delv_cost'
+        ]
+        int_fields = [
+            'sale_cnt', 'box_ea', 'p_ea', 'mall_order_seq', 'acnt_regs_srno'
+        ]
+        date_fields = ['order_date']
+
+        def parse_date_field(val: str) -> date | None:
+            if not val:
+                return None
+            try:
+                if len(val) == 8:
+                    return datetime.strptime(val, '%Y%m%d').date()
+                elif len(val) == 14:
+                    return datetime.strptime(val, '%Y%m%d%H%M%S').date()
+                else:
+                    return None
+            except Exception as e:
+                write_log(f"order_date 변환 실패: {val} ({e})")
+                return None
+
         try:
             root = ET.fromstring(xml_content)
             order_list = []
             for data_node in root.findall('DATA'):
                 order_detail = {}
                 for elem in data_node.findall('*'):
-                    elem_tag = elem.tag.strip() if elem.tag else ''
+                    elem_tag = elem.tag.strip().lower() if elem.tag else ''
                     elem_text = elem.text.strip() if elem.text else ''
                     if elem.tag is not None and elem.text is not None:
-                        if safe_mode and (elem_tag in MASKING_RULES):
-                            mask_type = MASKING_RULES[elem_tag]
+                        if safe_mode and (elem_tag.upper() in MASKING_RULES):
+                            mask_type = MASKING_RULES[elem_tag.upper()]
                             elem_text = self.__mask_personal_info(elem_text, mask_type)
-                        order_detail[elem_tag.lower()] = elem_text
+                        order_detail[elem_tag] = elem_text
                 order_detail["receive_dt"] = datetime.now()
+                for field in decimal_fields:
+                    if field in order_detail:
+                        try:
+                            order_detail[field] = Decimal(order_detail[field]) if order_detail[field] != '' else None
+                        except Exception as e:
+                            write_log(f"{field} Decimal 변환 실패: {order_detail[field]} ({e})")
+                            order_detail[field] = None
+                for field in int_fields:
+                    if field in order_detail:
+                        try:
+                            order_detail[field] = int(order_detail[field]) if order_detail[field] != '' else None
+                        except Exception as e:
+                            write_log(f"{field} int 변환 실패: {order_detail[field]} ({e})")
+                            order_detail[field] = None
+                for field in date_fields:
+                    if field in order_detail:
+                        order_detail[field] = parse_date_field(order_detail[field])
                 order_list.append(order_detail)
-            logger.info(f"총 {len(order_list)}개의 주문을 DB에 저장합니다.")
+            write_log(f"총 {len(order_list)}개의 주문을 DB에 저장합니다.")
             inserter = CreateReceiveOrder()
             inserted = 0
             for order_data in order_list:
@@ -151,20 +199,21 @@ class OrderListFetchService:
                     await inserter.create(obj_in=order_model)
                     inserted += 1
                 except Exception as e:
-                    logger.error(f"DB 저장 실패: {e} (data: {order_data})")
+                    write_log(f"DB 저장 실패: {e} (data: {order_data})")
+            write_log(f"DB에 저장된 주문 수: {inserted}")
             return inserted
         except ET.ParseError as e:
-            logger.error(f"XML 파싱 오류: {e}")
+            write_log(f"XML 파싱 오류: {e}")
             raise
         except Exception as e:
-            logger.error(f"DB 저장 중 오류: {e}")
+            write_log(f"DB 저장 중 오류: {e}")
             raise
 
     def get_order_list_via_url(self, xml_url: str, to_db: bool = False) -> List[Dict[str, str]]:
         try:
             api_url = urljoin(self.admin_url, '/RTL_API/xml_order_info.html')
             full_url = f"{api_url}?xml_url={xml_url}"
-            logger.info(f"최종 요청 URL: {full_url}")
+            logger.error(f"최종 요청 URL: {full_url}")
             print(f"최종 요청 URL: {full_url}")
             response = requests.get(full_url, timeout=30)
             print(f"API 요청 결과: {response.text}")
@@ -172,7 +221,7 @@ class OrderListFetchService:
             if to_db:
                 import asyncio
                 inserted = asyncio.run(self.parse_response_xml_to_db(response.text))
-                logger.info(f"DB에 저장된 주문 수: {inserted}")
+                logger.error(f"DB에 저장된 주문 수: {inserted}")
                 return []
             else:
                 response_xml = self.parse_response_xml_to_json(response.text)

--- a/services/order_list_write.py
+++ b/services/order_list_write.py
@@ -18,3 +18,17 @@ class OrderListWriteService:
         for order_data in order_data_list:
             order_model = self.convert_to_model(order_data)
             await self.create_receive_order.create(obj_in=order_model)
+
+    async def create_orders_from_xml(self, xml_content: str) -> int:
+        """
+        Parse the given XML content and insert orders into the DB using OrderListFetchService.
+        Returns the number of inserted records.
+        """
+        from services.order_list_fetch import OrderListFetchService
+        fetch_service = OrderListFetchService(
+            ord_st_date="",  # Not needed for this context
+            ord_ed_date="",
+            order_status=""
+        )
+        inserted = await fetch_service.parse_response_xml_to_db(xml_content)
+        return inserted

--- a/utils/log_utils.py
+++ b/utils/log_utils.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+from datetime import datetime
+
+def write_log(message: str, log_name: str = "order_import.log") -> None:
+    """
+    Append a log message to the specified log file in the logs directory.
+    Each message is prepended with a timestamp.
+    The log file name will include a MMddhhmm timestamp to distinguish logs.
+    """
+    logs_dir = Path("./logs")
+    logs_dir.mkdir(exist_ok=True)
+    # Add MMddhhmm timestamp to log file name
+    timestamp_for_filename = datetime.now().strftime("%m%d%H%M")
+    if log_name.endswith(".log"):
+        log_name = log_name[:-4] + f"_{timestamp_for_filename}.log"
+    else:
+        log_name = log_name + f"_{timestamp_for_filename}"
+    log_path = logs_dir / log_name
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"[{timestamp}] {message}\n") 


### PR DESCRIPTION
## 주요 내용 요약

## [사용자 입력] → [주문 데이터 수집] → [저장 방식 선택(DB/JSON)] → [XML 파싱] → [DB 저장 또는 JSON 저장] → [로깅]

### Modified 
- services/order_list_fetch.py
  - parse_response_xml_to_db와 parse_response_xml_to_json 함수가 새로 분리/추가되었습니다.
- services/order_list_write.py
  - OrderListWriteService 클래스에 새로운 메서드 create_orders_from_xml이 추가되었습니다.
- .gitignore
  - logs/* 폴더 추가
- models/receive_order/receive_order.py
  - mall_order_seq 필드의 타입이 Integer에서 BigInteger로 변경되었습니다.
- controller/order_list.py
  - 주문 데이터 저장 방식을 DB 저장과 JSON 파일 저장 중 선택할 수 있도록 기능이 추가되었습니다. 

### Added
- utils/log_utils.py
  - 로그 기록을 위한 유틸리티 함수 write_log가 추가되었습니다.

## 상세 내용 정리
### Modified 
- services/order_list_fetch.py
	1. 기능 분리:
		- XML 응답을 DB에 저장하는 함수(parse_response_xml_to_db, 비동기)와
		- JSON 파일로 저장하는 함수(parse_response_xml_to_json, 동기)가 분리되었습니다.
	2. 데이터 타입 처리 강화:
		- parse_response_xml_to_db에서 금액, 수량, 날짜 필드에 대해 Decimal, int, date 타입으로 변환 처리 로직이 추가되었습니다.
		- 변환 실패 시 로그를 남기고 None 처리합니다.
	3. 로깅 개선:
		- 기존 logger.error 외에, 주요 데이터 변환 및 DB 저장 실패 시 utils.log_utils.write_log를 활용해 상세 로그를 남깁니다.
	4. 마스킹 로직 개선:
		- 개인정보 마스킹 함수(__mask_personal_info)가 두 함수에서 공통적으로 사용됩니다.
	5. 기타:
		- get_order_list_via_url에서 to_db 옵션에 따라 두 함수 중 하나를 호출하도록 변경되었습니다.

- services/order_list_write.py
	1. XML → DB 직접 저장 기능 추가:
		- create_orders_from_xml(xml_content: str) -> int
		- XML 문자열을 받아서, 내부적으로 OrderListFetchService의 parse_response_xml_to_db를 호출하여 주문 데이터를 DB에 저장합니다.
		- 저장된 레코드 수를 반환합니다.
	2. 기존 JSON 기반 저장과 분리:
		- 기존에는 JSON 파일(order_list.json)을 읽어 DB에 저장하는 create_orders만 있었으나,
		- 이제 XML을 바로 받아 DB에 저장하는 경로가 추가되었습니다.
	3. 내부 의존성:
		- OrderListFetchService를 동적으로 import하여 XML 파싱 및 DB 저장을 위임합니다.
		- 날짜, 상태 등은 빈 값으로 생성자에 전달(이 컨텍스트에서는 필요 없음).
- .gitignore
	1. logs/* 폴더 추가
- models/receive_order/receive_order.py
	- mall_order_seq 필드의 타입이 Integer에서 BigInteger로 변경되었습니다.
- controller/order_list.py
	1. 저장 방식 선택 함수 추가
		- select_order_save_method() 함수가 새로 추가되어, 사용자에게 "1. DB에 저장(권장)" 또는 "2. JSON 파일로 저장" 중 하나를 입력받아 선택할 수 있게 함.
		- 잘못된 입력 시 기본값(JSON 저장)으로 진행.
	2. 주문 수집 메인 로직 연동
		- fetch_order_list()에서 주문 수집 방식 선택 후, to_db 변수에 저장 방식 결과를 받아옴.
		- 이후 주문 수집 함수(get_order_list_via_url) 호출 시 to_db 인자를 전달하여, DB 저장 또는 JSON 저장이 동작하도록 분기 처리.
	3. 결과 메시지 분기
		- 저장 방식에 따라 "성공적으로 DB에 저장되었습니다." 또는 "성공적으로 저장되었습니다. (경로: ./json/order_list.json)" 메시지 출력.

### Added
- utils/log_utils.py
	1. 로그 파일 자동 생성 및 관리
		- ./logs 디렉토리가 없으면 자동 생성.
		- 로그 파일명에 MMddhhmm(월일시분) 타임스탬프가 붙어, 시간별로 구분된 로그 파일 생성.
	2. 타임스탬프 포함 메시지 기록
		- 각 로그 메시지는 [YYYY-MM-DD HH:MM:SS] 형식의 타임스탬프와 함께 파일에 append(추가)됨.
	3. 사용 예시
		- write_log("주문 데이터 저장 성공") 처럼 호출하면, 지정된 로그 파일에 메시지가 남음.
## 이슈 (옵션)
#50 order list Data type & Size 관련 데이터 전처리 필요

## 관련 이슈
#48 [feat] 주문수집 API 제작

closes #50 