### PR TITLE
Issue:receive_oders 중복 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 *.xml
 *.log
 *.json
+files/*
 
 */__pycache__/*
 

--- a/models/receive_order/receive_order.py
+++ b/models/receive_order/receive_order.py
@@ -20,7 +20,7 @@ class ReceiveOrder(Base):
     # 기본 정보
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     receive_dt: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False))
-    idx: Mapped[str | None] = mapped_column(String(50))
+    idx: Mapped[str | None] = mapped_column(String(50), unique=True)
     order_id: Mapped[str | None] = mapped_column(String(100))
     mall_id: Mapped[str | None] = mapped_column(String(100))
     mall_user_id: Mapped[str | None] = mapped_column(String(100))
@@ -98,7 +98,7 @@ class ReceiveOrder(Base):
 
     # 기타 처리 정보
     jung_chk_yn: Mapped[str | None] = mapped_column(String(2))
-    mall_order_seq: Mapped[int | None] = mapped_column(BigInteger)
+    mall_order_seq: Mapped[str | None] = mapped_column(String(20))
     mall_order_id: Mapped[str | None] = mapped_column(String(100))
     etc_field3: Mapped[str | None] = mapped_column(Text)
     ord_field2: Mapped[str | None] = mapped_column(String(10))

--- a/repository/receive_order_repository.py
+++ b/repository/receive_order_repository.py
@@ -2,6 +2,7 @@ from typing import Optional
 from core.db import get_async_session
 from models.receive_order.receive_order import ReceiveOrder
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 class CreateReceiveOrder:
     async def create(self, obj_in: ReceiveOrder) -> ReceiveOrder:
@@ -24,6 +25,20 @@ class CreateReceiveOrder:
             result = await session.execute(query)
             content = result.scalars().all()
             return content
+        except Exception as e:
+            await session.rollback()
+            raise e
+        finally:
+            await session.close()
+
+    async def query_create(self, obj_in: dict) -> dict:
+        session = await get_async_session()
+        try:
+            query = pg_insert(ReceiveOrder).values(obj_in)
+            query = query.on_conflict_do_update(index_elements=['idx'], set_=obj_in)
+            await session.execute(query)
+            await session.commit()
+            return obj_in
         except Exception as e:
             await session.rollback()
             raise e

--- a/services/order_list/order_list_fetch.py
+++ b/services/order_list/order_list_fetch.py
@@ -134,7 +134,7 @@ class OrderListFetchService:
             'total_cost', 'pay_cost', 'sale_cost', 'mall_won_cost', 'won_cost', 'delv_cost'
         ]
         int_fields = [
-            'sale_cnt', 'box_ea', 'p_ea', 'mall_order_seq', 'acnt_regs_srno'
+            'sale_cnt', 'box_ea', 'p_ea', 'acnt_regs_srno'
         ]
         date_fields = ['order_date']
 
@@ -190,7 +190,9 @@ class OrderListFetchService:
             for order_data in order_list:
                 try:
                     order_model = ReceiveOrder(**order_data)
-                    await inserter.create(obj_in=order_model)
+                    data_dict = order_model.__dict__.copy()
+                    data_dict.pop('_sa_instance_state', None)
+                    await inserter.query_create(obj_in=data_dict)
                     inserted += 1
                 except Exception as e:
                     write_log(f"DB 저장 실패: {e} (data: {order_data})")


### PR DESCRIPTION
📋 프로세스 시각화
주문 수집 → XML 파싱 → DB 저장(중복 방지) 플로우 개선


🎯 개요
주문 데이터 저장 시 중복 방지 및 데이터 타입 일관성 확보
receive_oders model 타입 수ㅈ정.
files 디렉토리 내 불필요 파일 업로드 방지


🔄 변경 사항
<details>
<summary><strong>🔸 Repository 계층 개선</strong></summary>
CreateReceiveOrder.query_create 메서드 신설: dict 기반 upsert 지원 및 중복(idx) 방지
기존 create 방식에서 dict 변환 및 upsert로 변경
DB 저장 후 ORM 인스턴스 대신 dict 반환으로 단순화
</details>


🆕 주요 신규 · 변경 기능
.gitignore에 files/* 추가 (불필요 파일 업로드 방지)
ReceiveOrder.idx 필드에 unique 제약 추가 (중복 주문 방지)
ReceiveOrder.mall_order_seq 타입을 BigInteger → String(20)으로 변경 (타입 불일치 이슈 해결)
CreateReceiveOrder에 query_create(dict 기반 upsert) 메서드 추가
주문 저장 로직에서 ORM 인스턴스 → dict 변환 후 저장하도록 변경


🏗️ 아키텍처 개선사항
DB upsert 시 ORM 인스턴스가 아닌 dict를 사용하여 SQLAlchemy의 insert + on_conflict_do_update 활용
중복 주문(idx 기준) 저장 방지
서비스 계층에서 데이터 타입 변환 및 dict 변환 명확화


🔄 처리 플로우
XML 파싱 → dict 변환
dict → ORM 인스턴스 → dict 변환(내부 속성 제거)
query_create로 upsert (중복 idx는 update)
저장 결과 dict 반환


🎯 관련 이슈
주문 데이터 중복 저장
DB 저장 시 타입 불일치 및 예외 발생


🔍 데이터 스키마 변경
ReceiveOrder.idx : unique 제약 추가
ReceiveOrder.mall_order_seq : BigInteger → String(20)으로 변경


close #107 