### PR TITLE
fix: update test mode condition for XML generation in product registr…

### DIFF
--- a/utils/make_xml/product_registration_xml.py
+++ b/utils/make_xml/product_registration_xml.py
@@ -29,7 +29,7 @@ class ProductRegistrationXml(SabangnetXml):
         for db_field, xml_tag_name in get_db_to_xml_mapping().items():
             if xml_tag_name:
                 db_value = getattr(product_data, db_field, None)
-                if SETTINGS.TEST_MODE:
+                if SETTINGS.CONPANY_GOODS_CD_TEST_MODE:
                     self._make_test_xml_element(xml_tag_name, db_field, db_value, data, row_idx)
                 else:
                     child = ET.SubElement(data, xml_tag_name)
@@ -51,7 +51,7 @@ class ProductRegistrationXml(SabangnetXml):
         if file_name is None:
             now_str = datetime.now().strftime("%m%d%H%M")
             base_name = f"product_create_request_db_{now_str}_{product_create_db_count}.xml"
-            if SETTINGS.TEST_MODE:
+            if SETTINGS.CONPANY_GOODS_CD_TEST_MODE:
                 base_name = f"product_create_request_db_test_{now_str}_{product_create_db_count}.xml"
             file_name = f"{self._PATH}/" + sanitize_filename(base_name)
 


### PR DESCRIPTION
## 🎯 개요
상품 등록 XML 생성 시 테스트 모드 조건 분기를 기존 `SETTINGS.TEST_MODE`에서 `SETTINGS.CONPANY_GOODS_CD_TEST_MODE`로 일원화하여, 환경변수 기반의 테스트 모드 동작을 명확하게 반영합니다.

## 🔄 주요 변경 사항
<details>
<summary><strong>🔸 상세 변경 내역 보기 (클릭)</strong></summary>

- `utils/make_xml/product_registration_xml.py`  
  - 상품 등록 XML 생성 시 테스트 모드 분기 조건을 `SETTINGS.CONPANY_GOODS_CD_TEST_MODE`로 변경
  - 파일명 생성 및 XML 엘리먼트 생성 시 동일하게 적용
- 기존의 `SETTINGS.TEST_MODE` 사용 부분을 모두 일관성 있게 수정

</details>

## 🆕 신규 및 변경된 기능
- 환경변수 `CONPANY_GOODS_CD_TEST_MODE` 값에 따라 상품 등록 XML이 테스트 모드로 생성됨
- 테스트 모드 활성화 시 파일명 및 XML 내용이 테스트용으로 생성됨

## 🏗️ 아키텍처/구조 개선
- 테스트 모드 분기 조건을 환경변수 기반으로 통일하여, 설정 관리의 일관성과 명확성 향상

## 🔄 처리 플로우
- 상품 등록 데이터 → `ProductRegistrationXml` →  
  `SETTINGS.CONPANY_GOODS_CD_TEST_MODE` 값에 따라  
  → 테스트용 XML 생성 또는 일반 XML 생성

## 🎯 관련 이슈
- **Issue**: #106   

## 🔍 데이터/스키마 변경
- `.env` 파일 내 `CONPANY_GOODS_CD_TEST_MODE` 환경변수 사용  
  (README 및 .env 예시 파일에 이미 명시됨)

## 🏆 기대 효과
- 테스트 모드 동작의 명확성 및 유지보수성 향상
- 환경설정만으로 테스트 모드 전환 가능 → 운영/테스트 환경 분리 용이

## 📂 주요 변경 파일
- utils/make_xml/product_registration_xml.py