### PR TITLE
Fix/ 주문관리- 합포장 지그재그 금액 이슈

### DIFF
--- a/utils/macros/happojang/zigzag_merge_packaging.py
+++ b/utils/macros/happojang/zigzag_merge_packaging.py
@@ -203,24 +203,25 @@ def zigzag_merge_packaging(input_path: str) -> str:
             m_val = str(ws[f"M{row}"].value)
             ws[f"V{row}"].value = lookup_map.get(m_val, "")
     
-    # 4. D열 수식 설정 (=U+V)
-    ex.autofill_d_column(formula="=U{row}+V{row}")
     
-    # 5. 상품정보 처리 (다중수량 강조)
+    # 4. 상품정보 처리 (다중수량 강조)
     highlight_multiple_items(ws)
     
-    # 6. A열 순번 설정
+    # 5. A열 순번 설정
     ex.set_row_number(ws)
     
-    # 7. 열 정렬
+    # 6. 열 정렬
     ex.set_column_alignment()
     
-    # 8. 배경·테두리 제거
+    # 7. 배경·테두리 제거
     ex.clear_fills_from_second_row()
     ex.clear_borders()
     
-    # 9. C→B 정렬
+    # 8. C→B 정렬
     ex.sort_by_columns([2, 3])
+
+    # 9. D열 금액 계산 설정 (=U+V)
+    ex.calculate_d_column_values(first_col='U', second_col='V')
 
     # ========== 자동화 시트 생성 (맨 앞에 위치) ==========
     # 매크로가 적용된 전체 시트를 "자동화" 이름으로 맨 앞에 복사


### PR DESCRIPTION
## 🔧 fix: 지그재그 매크로 D열 금액 계산 오류 수정

## 📋 프로세스 시각화

```mermaid
graph TD
    F[열 정렬 및 서식]
    F --> G[C→B 정렬]
    G --> H[D열 금액 계산 수정]
```

## 🎯 개요

지그재그 쇼핑몰 주문 합포장 매크로에서 D열 계산 로직의 처리 순서와 메서드 호출 방식을 수정했습니다. 기존 `autofill_d_column()` 메서드에서 발생하던 수식 처리 문제를 `calculate_d_column_values()` 메서드로 대체하여 type 에러오류를 예방했습니다.

## 🔄 변경 사항

<details>
<summary><strong>🔸 D열 금액 계산 로직 개선</strong></summary>

- 기존 `autofill_d_column(formula="=U{row}+V{row}")` 메서드 제거
- `calculate_d_column_values(first_col='U', second_col='V')` 메서드로 대체
- 수식 기반 계산에서 직접 값 계산 방식으로 변경하여 안정성 향상
- - D열 계산을 C→B 정렬 이후로 이동 (기존 4번째 → 9번째 단계)

</details>

## 🆕 주요 변경 기능

### 1. 안정적인 금액 계산
- **Before**: `=U{row}+V{row}` 수식으로 D열 자동 채움
- **After**: U열과 V열의 실제 값을 직접 합산하여 D열에 입력
- 데이터 정렬 완료 후 금액 계산 수행으로 정확도 향상
- 수식 오류 및 참조 문제 완전 해결

## 🏗️ 아키텍처 개선사항

### 메서드 호출 방식 개선
```python
# Before (수식 기반)
ex.autofill_d_column(formula="=U{row}+V{row}")

# After (직접 계산)
ex.calculate_d_column_values(first_col='U', second_col='V')
```

## 🔄 처리 플로우

기존 플로우 유지하되, D열 계산 타이밍만 정렬 완료 후로 변경:

```
6. 열 정렬
7. 배경·테두리 제거
8. C→B 정렬 ← 정렬 완료
9. D열 금액 계산 ← 4번에서 9번으로 수정
```

## 🎯 관련 이슈

- #260 
- 지그재그 매크로 실행 시 D열 금액 계산 오류 발생 

## 🏆 기대 효과

### 1. 안정성 향상
- D열 금액 계산 오류 안정성 향상
- 수식 참조 문제로 인한 처리 실패 방지
- 대용량 데이터 처리 시에도 안정적 동작 보장
- - 정렬 완료 후 금액 계산으로 **정확도 향상**


## 📂 주요 변경 파일

### Modified Files
- `utils/macros/happojang/zigzag_merge_packaging.py`
  - `autofill_d_column()` → `calculate_d_column_values()` 메서드 변경
  - 처리 순서 조정 (4번째 → 9번째 단계)
  - 단계별 주석 번호 재정렬
