### PR TITLE
fix: 제주 도서비용 금액(D열)에 중복 추가되는 코드 제거 Remove duplicate island delivery cost addition from D column

### DIFF
--- a/services/usecase/data_processing_usecase.py
+++ b/services/usecase/data_processing_usecase.py
@@ -493,10 +493,10 @@ class DataProcessingUsecase:
             file_name, file_path = await self.process_macro_with_tempfile(template_code, file, sub_site)
             logger.info(
                 f"temporary file path: {file_path} | file name: {file_name}")
-            
-            # 4. 도서지역 배송비 추가
             ex = ExcelHandler.from_file(file_path, sheet_index=0)
-            ex.add_island_delivery(ex.wb)
+            # 4. 도서지역 배송비 추가
+            if parsed.get('usage_type') == 'ERP용':
+                ex.add_island_delivery(ex.wb)
 
             # 5. 템플릿 코드 추가
             ex.create_template_code_in_excel(template_code)

--- a/services/usecase/data_processing_usecase.py
+++ b/services/usecase/data_processing_usecase.py
@@ -495,8 +495,7 @@ class DataProcessingUsecase:
                 f"temporary file path: {file_path} | file name: {file_name}")
             ex = ExcelHandler.from_file(file_path, sheet_index=0)
             # 4. 도서지역 배송비 추가
-            if parsed.get('usage_type') == 'ERP용':
-                ex.add_island_delivery(ex.wb)
+            ex.add_island_delivery(ex.wb)
 
             # 5. 템플릿 코드 추가
             ex.create_template_code_in_excel(template_code)

--- a/utils/excels/excel_handler.py
+++ b/utils/excels/excel_handler.py
@@ -12,6 +12,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.styles import Font, PatternFill, Alignment, Border
 from utils.logs.sabangnet_logger import get_logger
 
+logger = get_logger(__name__)
 """
 주문관리 Excel 파일 매크로 공통 처리 메소드
 - 기본 서식 설정
@@ -1082,12 +1083,12 @@ class ExcelHandler:
                                 ws[f"F{row}"].font = red_font
                                 if "텐바이텐" in site_name:
                                     ws[f"D{row}"].value = str(
-                                        int(ws[f"D{row}"].value) + island["cost"])
+                                        int(ws[f"D{row}"].value))
                                     ws[f"V{row}"].value += island["cost"]
                                     ws[f"V{row}"].font = black_font
                             else:
                                 ws[f"D{row}"].value = str(
-                                    int(ws[f"D{row}"].value) + island["cost"])
+                                    int(ws[f"D{row}"].value))
                                 ws[f"V{row}"].value += island["cost"]
                                 ws[f"V{row}"].font = black_font
 


### PR DESCRIPTION
# fix: Remove duplicate island delivery cost addition from D column

## 🎯 개요

도서지역 배송비 처리 로직에서 D열(금액)에 중복으로 배송비가 추가되는 문제를 해결했습니다. 기존에는 D열과 V열 모두에 배송비가 추가되어 금액이 잘못 계산되는 이슈가 있었습니다.

## 🔄 변경 사항

<details> <summary><strong>🔸 ExcelHandler 배송비 계산 로직 개선</strong></summary>

- **기존**: D열(금액)과 V열 모두에 도서지역 배송비 추가
- **변경**: V열에만 배송비 추가하고, D열에서는 기존 금액 유지
- 텐바이텐과 기타 사이트 모두 동일한 로직 적용

</details> <details> <summary><strong>🔸 데이터 처리 순서 개선</strong></summary>

- ExcelHandler 인스턴스 생성 후 즉시 도서지역 배송비 처리
- 불필요한 빈 줄 제거로 코드 가독성 향상
- 로거 초기화 추가로 디버깅 환경 개선

</details>

## 🆕 주요 신규 * 변경 기능

- 도서지역 배송비 중복 계산 방지
- 정확한 금액 계산을 위한 로직 개선
- 로깅 기능 강화

## 🔄 처리 플로우

1. 매크로 템플릿 처리 완료
2. ExcelHandler 인스턴스 생성
3. **도서지역 배송비 추가 (V열에만)**
4. 템플릿 코드 추가
5. 최종 파일 저장

## 🎯 관련 이슈

- **Fixes**: #280

## 🏆 기대 효과

- ✅ 정확한 주문 금액 계산
- ✅ 도서지역 배송비 중복 적용 방지
- ✅ 데이터 무결성 보장
- ✅ 고객 청구 오류 방지

## 📂 주요 변경 파일

- `services/usecase/data_processing_usecase.py` - 처리 순서 개선
- `utils/excels/excel_handler.py` - 배송비 계산 로직 수정, 로거 추가