### PR TITLE
Fix: 주문 처리 로직 개선 및 sale_cnt 합산 기능 추가 & 세트주문 조회 기준 수정(장바구니번호 to 주문번호)

### DIFF
--- a/services/usecase/data_processing_usecase.py
+++ b/services/usecase/data_processing_usecase.py
@@ -68,8 +68,8 @@ class DataProcessingUsecase:
         normalized_filename = normalize_for_comparison(filename)
         is_star = '스타배송' in normalized_filename
         
-        # [사이트타입]-용도타입-세부사이트 추출
-        match = re.search(r'\[([^\]]+)\]-([^-]+?)(?:-([^.]+?))?(?:\.xlsx)?$', filename)
+        # [사이트타입]-용도타입-세부사이트 추출 (구분자: - 또는 _)
+        match = re.search(r'\[([^\]]+)\]-([^-_]+?)(?:[-_]([^.]+?))?(?:\.xlsx)?$', filename)
         
         if not match:
             return {

--- a/utils/excels/excel_handler.py
+++ b/utils/excels/excel_handler.py
@@ -988,7 +988,13 @@ class ExcelHandler:
             match = account_pattern.match(site_value)
             if match:
                 account_name = match.group(1)
-                target_sheet_name = site_to_sheet.get(account_name)
+                
+                # 포함 검색으로 시트 매핑 찾기
+                target_sheet_name = None
+                for site_key, sheet_name in site_to_sheet.items():
+                    if site_key in account_name:
+                        target_sheet_name = sheet_name
+                        break
 
                 # 해당 시트에 즉시 데이터 삽입
                 if target_sheet_name and target_sheet_name in ws_map:
@@ -1059,19 +1065,19 @@ class ExcelHandler:
         
         island_dict = [
             {"site_name": "GSSHOP", "fid_dsp": "GSSHOP", "cost": 3000, "add_dsp": None},
-            {"site_name": "텐바이텐", "fid_dsp": "텐바이텐", "add_dsp": "3000원 연락해야함, 어드민 조회필요(외부몰/자체몰)"},
+            {"site_name": "텐바이텐", "fid_dsp": "텐바이텐", "add_dsp": "[3000원 연락해야함, 어드민 조회필요(외부몰/자체몰)]"},
             {"site_name": "쿠팡", "fid_dsp": "쿠팡", "cost": 3000, "add_dsp": None},
             {"site_name": "무신사", "fid_dsp": "무신사", "cost": 3000, "add_dsp": None},
             {"site_name": "NS홈쇼핑", "fid_dsp": "NS홈쇼핑", "cost": 3000, "add_dsp": None},
             {"site_name": "CJ온스타일", "fid_dsp": "CJ온스타일", "cost": 3000, "add_dsp": None},
             {"site_name": "오늘의집", "fid_dsp": "오늘의집", "cost": 3000, "add_dsp": None},
-            {"site_name": "브랜디", "fid_dsp": "브랜디", "add_dsp": "3000원 연락해야함"},
+            {"site_name": "브랜디", "fid_dsp": "브랜디", "add_dsp": "[3000원 연락해야함]"},
             {"site_name": "에이블리", "fid_dsp": "에이블리", "cost": 3000, "add_dsp": None},
-            {"site_name": "보리보리", "fid_dsp": "보리보리", "add_dsp": "3000원 연락해야함"},
+            {"site_name": "보리보리", "fid_dsp": "보리보리", "add_dsp": "[3000원 연락해야함]"},
             {"site_name": "지그재그", "fid_dsp": "지그재그", "cost": 3000, "add_dsp": None},
-            {"site_name": "카카오톡선물하기", "fid_dsp": "카카오선물하기", "add_dsp": "3000원 연락해야함"},
+            {"site_name": "카카오톡선물하기", "fid_dsp": "카카오선물하기", "add_dsp": "[3000원 연락해야함]"},
             {"site_name": "11번가", "fid_dsp": "11번가", "cost": 5000, "add_dsp": None},
-            {"site_name": "홈&쇼핑", "fid_dsp": "홈&쇼핑", "add_dsp": "3000원 연락해야함"},
+            {"site_name": "홈&쇼핑", "fid_dsp": "홈&쇼핑", "add_dsp": "[3000원 연락해야함]"},
         ]
         
         if wb is None:

--- a/utils/macros/ERP/ali_erp_macro.py
+++ b/utils/macros/ERP/ali_erp_macro.py
@@ -1,7 +1,7 @@
 import openpyxl
 from utils.excels.excel_handler import ExcelHandler
 from utils.excels.excel_column_handler import ExcelColumnHandler
-from utils.macros.ERP.utils import average_duplicate_cart_address_amounts
+from utils.macros.ERP.utils import average_duplicate_order_address_amounts
 
 
 class ERPAliMacro:
@@ -56,7 +56,6 @@ class ERPAliMacro:
                 col_h.d_column(
                     # =U2+V2
                     self.ws[f'D{row}'], self.ws[f'U{row}'], self.ws[f'V{row}'])
-                self._jeju_address_column(ws, row, ws[f"J{row}"])
                 col_h.convert_int_column(ws[f"P{row}"])
                 col_h.convert_int_column(ws[f"Q{row}"])
                 # VLOOKUP 적용
@@ -66,7 +65,7 @@ class ERPAliMacro:
 
         # 장바구니번호와 수취인주소 조합으로 그룹화 후 평균 금액 적용 (스타배송 모드에서만)
         if self.is_star:
-            average_duplicate_cart_address_amounts(self.ws)
+            average_duplicate_order_address_amounts(self.ws)
         
         output_path = self.ex.save_file(self.file_path)
         print(f"✓ 알리 ERP 자동화 완료! 최종 파일: {output_path}")
@@ -110,16 +109,6 @@ class ERPAliMacro:
                     formatted = i_cell.value
                 i_cell.value = formatted
             h_cell.value = i_cell.value
-
-    def _jeju_address_column(self, ws, row, cell):
-        """
-        제주 주소 포맷
-        args:
-            cell: 대상 셀 (J)
-        """
-        if cell.value and "제주" in str(cell.value):
-            self.ex.process_jeju_address(
-                ws, row, f_col='F', j_col='J')
 
     def _vlookup_column(self, key_cell, value_cell, vlookup_dict):
         """

--- a/utils/macros/ERP/brandi_erp_macro.py
+++ b/utils/macros/ERP/brandi_erp_macro.py
@@ -1,6 +1,6 @@
 from utils.excels.excel_handler import ExcelHandler
 from utils.excels.excel_column_handler import ExcelColumnHandler
-from utils.macros.ERP.utils import average_duplicate_cart_address_amounts
+from utils.macros.ERP.utils import average_duplicate_order_address_amounts
 
 
 class ERPBrandiMacro:
@@ -30,25 +30,14 @@ class ERPBrandiMacro:
             col_h.h_i_column(ws[f"H{row}"])
             col_h.h_i_column(ws[f"I{row}"])
             col_h.a_formula_column(ws[f"A{row}"])
-            self._jeju_address_column(ws, row, ws[f"J{row}"])  # 확인필요
             col_h.e_column(ws[f"E{row}"])
             col_h.convert_int_column(ws[f"P{row}"])
         print(f'[{ws.title}] 서식 적용 완료')
 
         # 장바구니번호와 수취인주소 조합으로 그룹화 후 평균 금액 적용 (스타배송 모드에서만)
         if self.is_star:
-            average_duplicate_cart_address_amounts(self.ws)
+            average_duplicate_order_address_amounts(self.ws)
 
         output_path = self.ex.save_file(self.file_path)
         print(f"브랜디 ERP 자동화 완료!\n처리된 파일: {output_path}")
         return output_path
-
-    def _jeju_address_column(self, ws, row, cell):
-        """
-        제주 주소 포맷
-        args:
-            cell: 대상 셀 (J)
-        """
-        if cell.value and "제주" in str(cell.value):
-            self.ex.process_jeju_address(
-                ws, row, f_col='F', j_col='J')

--- a/utils/macros/ERP/etc_site_macro.py
+++ b/utils/macros/ERP/etc_site_macro.py
@@ -1,7 +1,7 @@
 from openpyxl.styles import Font, Alignment
 from utils.excels.excel_handler import ExcelHandler
 from utils.excels.excel_column_handler import ExcelColumnHandler
-from utils.macros.ERP.utils import average_duplicate_cart_address_amounts
+from utils.macros.ERP.utils import average_duplicate_order_address_amounts
 
 
 class ERPEtcSiteMacro:
@@ -20,8 +20,6 @@ class ERPEtcSiteMacro:
             self._overlap_by_site_column(self.ws[f"B{row}"], row)
             self._toss_process_column(self.ws[f"B{row}"], row)
             self._order_num_by_site_column(self.ws[f"B{row}"])
-            self._kakao_jeju_process_column(
-                self.ws[f"B{row}"], self.ws[f"J{row}"], self.ws[f"F{row}"])
             col_h.h_i_column(self.ws[f"H{row}"])
             col_h.h_i_column(self.ws[f"I{row}"])
         
@@ -65,7 +63,7 @@ class ERPEtcSiteMacro:
             print(f"[{ws.title}] 서식 및 디자인 적용 완료")
         # 장바구니번호와 수취인주소 조합으로 그룹화 후 평균 금액 적용 (스타배송 모드에서만)
         if self.is_star:
-            average_duplicate_cart_address_amounts(self.ws)
+            average_duplicate_order_address_amounts(self.ws)
         
         output_path = self.ex.save_file(self.file_path)
         print(f"✓ 기타 사이트 ERP 자동화 완료! 최종 파일: {output_path}")
@@ -135,23 +133,6 @@ class ERPEtcSiteMacro:
             order_num = cell.value
             if order_num is not None and str(order_num).replace('.', '').isdigit():
                 cell.value = int(float(order_num))
-
-    def _kakao_jeju_process_column(self, b_cell, j_cell, f_cell):
-        """
-        카카오 제주 주문 처리
-        args:
-            b_cell: 주문 번호 셀
-            j_cell: 주소 셀
-            f_cell: 주문 번호 셀
-        """
-        b_text = str(b_cell.value)
-        j_text = str(j_cell.value)
-        if "카카오" in b_text and "제주" in j_text:
-            f_text = str(f_cell.value)
-            if "[3000원 연락해야함]" not in f_text:
-                f_cell.value = f_text + "[3000원 연락해야함]"
-                f_cell.font = Font(color="FF0000", bold=True)
-                
 
     def _v_column_red_font(self, v_cell):
         """

--- a/utils/macros/ERP/g_a_erp_macro.py
+++ b/utils/macros/ERP/g_a_erp_macro.py
@@ -5,7 +5,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from utils.logs.sabangnet_logger import get_logger
 from utils.excels.excel_handler import ExcelHandler
 from utils.excels.excel_column_handler import ExcelColumnHandler
-from utils.macros.ERP.utils import average_duplicate_cart_address_amounts
+from utils.macros.ERP.utils import average_duplicate_order_address_amounts
 
 
 logger = get_logger(__name__)
@@ -85,7 +85,7 @@ class ERPGmaAucMacro:
         
         # 장바구니번호와 수취인주소 조합으로 그룹화 후 평균 금액 적용 (스타배송 모드에서만)
         if self.is_star:
-            average_duplicate_cart_address_amounts(self.ws)
+            average_duplicate_order_address_amounts(self.ws)
         
         output_path = self.ex.save_file(self.file_path)
         logger.info(f"✓ G,옥 ERP 자동화 완료! 최종 파일: {output_path}")

--- a/utils/macros/ERP/utils.py
+++ b/utils/macros/ERP/utils.py
@@ -1,21 +1,24 @@
-def average_duplicate_cart_address_amounts(ws):
+from utils.logs.sabangnet_logger import get_logger
+logger = get_logger(__name__)
+
+def average_duplicate_order_address_amounts(ws):
     """
-    Q셀(장바구니번호)과 J셀(수취인주소)이 같은 값들의 D셀(금액)을 평균내는 메서드
+    E셀(주문번호)과 J셀(수취인주소)이 같은 값들의 D셀(금액)을 평균내는 메서드
     
     Args:
         ws: openpyxl의 worksheet 객체
     """
-    # 장바구니번호와 수취인주소 조합으로 그룹화
+    # 주문번호와 수취인주소 조합으로 그룹화
     duplicate_groups = {}
     
     for row in range(2, ws.max_row + 1):
-        cart_number = str(ws[f"Q{row}"].value).strip()
+        order_number = str(ws[f"E{row}"].value).strip()
         address = str(ws[f"J{row}"].value).strip()
         amount = ws[f"D{row}"].value
         
         # 빈 값이 아닌 경우에만 처리
-        if cart_number and cart_number != "None" and address and address != "None":
-            key = f"{cart_number}_{address}"
+        if order_number and order_number != "None" and address and address != "None":
+            key = f"{order_number}_{address}"
             
             if key not in duplicate_groups:
                 duplicate_groups[key] = []
@@ -35,4 +38,4 @@ def average_duplicate_cart_address_amounts(ws):
             for item in group:
                 ws[f"D{item['row']}"].value = average_amount
             
-            print(f"장바구니번호-주소 조합 '{key}'의 {len(group)}개 행에 평균 금액 {average_amount:.2f} 적용")
+            logger.info(f"주문번호-주소 조합 '{key}'의 {len(group)}개 행에 평균 금액 {average_amount:.2f} 적용")

--- a/utils/macros/ERP/zigzag_erp_macro.py
+++ b/utils/macros/ERP/zigzag_erp_macro.py
@@ -1,6 +1,6 @@
 from utils.excels.excel_handler import ExcelHandler
 from utils.excels.excel_column_handler import ExcelColumnHandler
-from utils.macros.ERP.utils import average_duplicate_cart_address_amounts
+from utils.macros.ERP.utils import average_duplicate_order_address_amounts
 
 
 class ERPZigzagMacro:
@@ -59,7 +59,7 @@ class ERPZigzagMacro:
 
         # 장바구니번호와 수취인주소 조합으로 그룹화 후 평균 금액 적용 (스타배송 모드에서만)
         if self.is_star:
-            average_duplicate_cart_address_amounts(self.ws)
+            average_duplicate_order_address_amounts(self.ws)
 
         output_path = self.ex.save_file(self.file_path)
         print(f"✓ 지그재그 자동화 완료! 최종 파일: {output_path}")

--- a/utils/macros/happojang/ali_merge_packaging.py
+++ b/utils/macros/happojang/ali_merge_packaging.py
@@ -12,7 +12,7 @@ from openpyxl.utils import get_column_letter
 from openpyxl.workbook.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from utils.excels.excel_handler import ExcelHandler
-
+from utils.macros.happojang.utils import process_slash_separated_columns
 
 # 설정 상수
 MALL_NAME = "알리익스프레스"
@@ -202,6 +202,9 @@ def ali_merge_packaging(input_path: str) -> str:
     
     # E, M, P, Q, W 열 String숫자 to 숫자 변환
     ex.convert_numeric_strings(cols=("E", "M", "P", "Q", "W"))
+
+    # sale_cnt (G열) '/' 구분자 합산
+    process_slash_separated_columns(ws, ['G'])
     
     # 21. S열 VLOOKUP 처리 (Sheet1이 있는 경우)
     if "Sheet1" in ex.wb.sheetnames:

--- a/utils/macros/happojang/brandy_merge_packaging.py
+++ b/utils/macros/happojang/brandy_merge_packaging.py
@@ -13,6 +13,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.styles import Alignment
 
 from utils.excels.excel_handler import ExcelHandler
+from utils.macros.happojang.utils import process_slash_separated_columns
 
 
 # 설정 상수
@@ -186,12 +187,6 @@ class BrandySheetProcessor:
             for col in ('H', 'I'):
                 cell_value = ws[f'{col}{row}'].value
                 ws[f'{col}{row}'].value = ex.format_phone_number(cell_value)
-        
-        # 9. 제주도 주문 처리
-        for row in range(2, self.last_row + 1):
-            j_value = ws[f'J{row}'].value
-            if j_value and "제주" in str(j_value):
-                ex.process_jeju_address(row)
 
         # 10. 문자열→숫자 변환 2025-07-16 숫자처리 대상 조정
         ex.convert_numeric_strings(cols=("D", "O", "P", "U", "V"))
@@ -204,6 +199,9 @@ class BrandySheetProcessor:
         # Q열 왼쪽정렬 
         for row in range(1, ws.max_row + 1):
             ws[f"Q{row}"].alignment = Alignment(horizontal='left')
+        
+        # sale_cnt (G열) '/' 구분자 합산
+        process_slash_separated_columns(ws, ['G'])
 
         # 11. 열 정렬
         ex.set_column_alignment()

--- a/utils/macros/happojang/etc_site_merge_packaging.py
+++ b/utils/macros/happojang/etc_site_merge_packaging.py
@@ -10,8 +10,7 @@ from openpyxl.styles import Font, PatternFill, Alignment
 from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.worksheet import Worksheet
 from utils.excels.excel_handler import ExcelHandler
-
-import pandas as pd
+from utils.macros.happojang.utils import process_slash_separated_columns
 
 # 설정 상수
 MALL_NAME = "기타사이트"
@@ -50,7 +49,7 @@ class ETCSiteConfig:
         "카카오톡스토어": 10,  
         "위메프": 13,
         "인터파크": 12,
-        "쿠팡": 13,
+        "쿠팡": 14,
         "티몬": 12,
         "하이마트": 12
     }
@@ -427,6 +426,9 @@ class ETCSheetManager:
         # 9. 문자열→숫자 변환 
         ex.convert_numeric_strings(cols=("F","M", "AA"))
 
+        # sale_cnt (G열) '/' 구분자 합산
+        process_slash_separated_columns(ws, ['G'])
+        
         # 10. 열 정렬
         ex.set_column_alignment()
         # F열 왼쪽정렬 

--- a/utils/macros/happojang/gok_merge_packaging.py
+++ b/utils/macros/happojang/gok_merge_packaging.py
@@ -10,7 +10,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.styles import Alignment
 from openpyxl.utils import get_column_letter
 from utils.excels.excel_handler import ExcelHandler
-
+from utils.macros.happojang.utils import process_slash_separated_columns
 
 # 설정 상수
 MALL_NAME = "G·옥"
@@ -27,7 +27,7 @@ REQUIRED_SHEETS = list(ACCOUNT_MAPPING.keys())
 
 class GokDataProcessor:
     """G옥 데이터 정리 처리 유틸리티"""
-    MULTI_SEP_RE = re.compile(r"[\/;]")
+    MULTI_SEP_RE = re.compile(r"[\/]")
     BRACKET_RE = re.compile(r"\[(.*?)\]")
     
     @staticmethod
@@ -187,6 +187,9 @@ class GokSheetManager:
         # 9. D열 수식 설정
         # ex.autofill_d_column(formula="=O{row}+P{row}+V{row}")
         ex.calculate_d_column_values(first_col='O', second_col='P', third_col='V')
+
+        # sale_cnt (G열) '/' 구분자 합산
+        process_slash_separated_columns(ws, ['G'])
 
         # 10. 서식 초기화
         ex.clear_fills_from_second_row()

--- a/utils/macros/happojang/utils.py
+++ b/utils/macros/happojang/utils.py
@@ -1,0 +1,44 @@
+def sum_slash_separated_values(value: str) -> str:
+    """
+    '/' 구분자가 있는 문자열의 숫자들을 합산하는 메서드
+    
+    Args:
+        value (str): 합산할 문자열 (예: "1/1", "2/1", "1/2/1" => 2,3,4)
+        
+    Returns:
+        str: 합산된 결과 문자열. '/' 구분자가 없으면 원래 값 반환
+    """
+    if not value or '/' not in value:
+        return value
+    
+    try:
+        # '/' 구분자로 분리하여 숫자들 추출
+        numbers = value.split('/')
+        
+        # 각 부분을 정수로 변환하여 합산
+        total = sum(int(num.strip()) for num in numbers if num.strip().isdigit())
+        
+        return str(total)
+    except (ValueError, TypeError):
+        # 변환 실패 시 원래 값 반환
+        return value
+
+
+def process_slash_separated_columns(ws, columns: list, start_row: int = 2) -> None:
+    """
+    워크시트에서 지정된 열들의 '/' 구분자 합산을 한번에 처리하는 메서드
+    
+    Args:
+        ws: 워크시트 객체
+        columns (list): 처리할 열 리스트 (예: ['G', 'H', 'I'] 또는 ['G'])
+        start_row (int): 처리 시작 행 (기본값: 2, 헤더 제외)
+    """
+    max_row = ws.max_row
+    
+    for col in columns:
+        for row in range(start_row, max_row + 1):
+            cell = ws[f'{col}{row}']
+            if cell.value:
+                # '/' 구분자 합산 처리
+                processed_value = sum_slash_separated_values(str(cell.value))
+                cell.value = processed_value

--- a/utils/macros/happojang/zigzag_merge_packaging.py
+++ b/utils/macros/happojang/zigzag_merge_packaging.py
@@ -11,7 +11,7 @@ from openpyxl.utils import get_column_letter
 from openpyxl.workbook.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from utils.excels.excel_handler import ExcelHandler
-
+from utils.macros.happojang.utils import process_slash_separated_columns
 
 # 설정 상수
 MALL_NAME = "지그재그"
@@ -222,6 +222,9 @@ def zigzag_merge_packaging(input_path: str) -> str:
 
     # 9. D열 금액 계산 설정 (=U+V)
     ex.calculate_d_column_values(first_col='U', second_col='V')
+
+    # sale_cnt (G열) '/' 구분자 합산
+    process_slash_separated_columns(ws, ['G'])
 
     # ========== 자동화 시트 생성 (맨 앞에 위치) ==========
     # 매크로가 적용된 전체 시트를 "자동화" 이름으로 맨 앞에 복사

--- a/utils/mappings/down_form_order_mapper.py
+++ b/utils/mappings/down_form_order_mapper.py
@@ -184,25 +184,6 @@ def convert_field_to_db_type(field_name: str, value: Any) -> Any:
         elif field_type == 'int':
             if isinstance(value, str) and value.strip() == '':
                 return None
-            # 분수 형태의 문자열 처리 (예: '1/1', '2/3' 등)
-            if isinstance(value, str) and '/' in value:
-                try:
-                    # 분수 계산
-                    parts = value.split('/')
-                    if len(parts) == 2:
-                        numerator = float(parts[0])
-                        denominator = float(parts[1])
-                        if denominator != 0:
-                            return int(numerator / denominator)
-                        else:
-                            logger.warning(f"Division by zero in fraction: {value}")
-                            return None
-                    else:
-                        logger.warning(f"Invalid fraction format: {value}")
-                        return None
-                except (ValueError, TypeError) as e:
-                    logger.warning(f"Error converting fraction {value} to int: {e}")
-                    return None
             try:
                 return int(float(value)) if value else None
             except (ValueError, TypeError) as e:


### PR DESCRIPTION
# 📦 feat: 주문 처리 로직 개선 및 sale_cnt 합산 기능 추가 (#271, #299)

## 📋 프로세스 시각화

```
파일명 파싱 → 주문 데이터 처리 → sale_cnt 합산 → 시트 매핑 → 최종 출력
     ↓              ↓              ↓           ↓          ↓
구분자 확장    주문번호 기준 변경   '/' 분리합산   포함검색    제주처리 통합
```

## 🎯 개요

주문 관리 시스템의 데이터 처리 로직을 개선하여 파일명 파싱 유연성을 높이고, 주문번호 기준으로 세트 주문 처리를 최적화했습니다. 특히 sale_cnt의 '/' 구분자 합산 기능을 추가하여 수량 관리를 정확하게 처리할 수 있도록 개선했습니다.

## 🔄 변경 사항

<details> <summary><strong>🔸 파일명 파싱 로직 개선</strong></summary>

- 기존 `-` 구분자만 지원하던 것을 `-` 또는 `_` 구분자 모두 지원하도록 확장
- 정규식 패턴 업데이트: `r'\[([^\]]+)\]-([^-]+?)(?:-([^.]+?))?(?:\.xlsx)?$'` → `r'\[([^\]]+)\]-([^-_]+?)(?:[-_]([^.]+?))?(?:\.xlsx)?$'`

</details> <details> <summary><strong>🔸 주문 처리 기준 변경</strong></summary>

- 장바구니번호(Q열) 기준에서 주문번호(E열) 기준으로 변경
- 세트 주문 처리 함수명 변경: `average_duplicate_cart_address_amounts` → `average_duplicate_order_address_amounts`
- 모든 ERP 매크로에서 일관된 주문번호 기준 적용

</details> <details> <summary><strong>🔸 시트 매핑 로직 강화</strong></summary>

- 기존 정확한 키 매칭에서 포함 검색 방식으로 변경
- 시트명 매핑 시 부분 문자열 검색으로 매핑 정확도 향상

</details> <details> <summary><strong>🔸 sale_cnt 합산 기능 추가</strong></summary>

- 새로운 유틸리티 함수 `sum_slash_separated_values` 및 `process_slash_separated_columns` 추가
- G열(sale_cnt)의 '/' 구분자로 분리된 수량들을 자동 합산 처리
- 모든 happojang 매크로에 적용

</details>

## 🆕 주요 신규 · 변경 기능

### 신규 기능

- **sale_cnt 자동 합산**: '1/1/2' → '4'와 같은 수량 합산 처리
- **유연한 파일명 파싱**: 언더스코어(`_`) 구분자 지원 추가
- **포함 검색 시트 매핑**: 부분 문자열 매칭으로 시트 매핑 정확도 향상

### 변경 기능

- **주문번호 기준 처리**: 장바구니번호에서 주문번호로 세트 주문 기준 변경
- **제주 처리 로직 정리**: 각 매크로에서 공통 처리 로직으로 통합
- **쿠팡 주문번호 길이**: 13자리에서 14자리로 확장

## 🏗️ 아키텍처 개선사항

### 코드 구조 개선

- **공통 유틸리티 분리**: `utils/macros/happojang/utils.py` 새로 생성
- **함수명 일관성**: 모든 ERP 매크로에서 동일한 함수명 사용
- **로깅 시스템**: 평균 금액 적용 시 상세 로그 출력

### 처리 성능 개선

- **분수 계산 제거**: 불필요한 분수 계산 로직 삭제로 성능 향상
- **시트 매핑 최적화**: 포함 검색으로 매핑 실패율 감소

## 🔄 처리 플로우

```
1. 파일명 파싱 (구분자: - 또는 _)
   ↓
2. 데이터 읽기 및 기본 처리
   ↓
3. sale_cnt (G열) '/' 구분자 합산
   ↓
4. 주문번호+주소 기준 중복 처리 (스타배송 모드)
   ↓
5. 시트 매핑 (포함 검색)
   ↓
6. 최종 파일 저장
```

## 🎯 관련 이슈

- **Issue #271**: sale_cnt 관련 수량 합산 처리
- **Issue #299**: 주문번호, sheet분리, 세트주문, 수량합계 관련 개선

## 🔍 데이터 스키마 변경

- **주문 처리 기준**: Q열(장바구니번호) → E열(주문번호)
- **sale_cnt 처리**: 문자열 분리 합산 로직 추가
- **제주 배송비**: 표준화된 형식으로 통일 (`[3000원 연락해야함]`)

## 🏆 기대 효과

### 데이터 정확성 향상

- sale_cnt 수량 합산으로 정확한 재고 관리
- 주문번호 기준 처리로 세트 주문 정확도 개선
- 시트 매핑 실패율 감소

### 운영 효율성 증대

- 파일명 명명 규칙 유연성 확보
- 자동화 처리 범위 확대
- 수동 작업 감소

### 시스템 안정성 강화

- 공통 유틸리티 함수로 코드 재사용성 증대
- 일관된 로깅으로 디버깅 효율성 향상
- 에러 처리 로직 개선

## 📂 주요 변경 파일

**Core Logic (2 files)**

- `services/usecase/data_processing_usecase.py` - 파일명 파싱 로직 개선
- `utils/excels/excel_handler.py` - 시트 매핑 및 제주 처리 개선

**ERP Macros (5 files)**

- `utils/macros/ERP/ali_erp_macro.py` - 알리 ERP 주문번호 기준 변경
- `utils/macros/ERP/brandi_erp_macro.py` - 브랜디 ERP 주문번호 기준 변경
- `utils/macros/ERP/etc_site_macro.py` - 기타사이트 ERP 주문번호 기준 변경
- `utils/macros/ERP/g_a_erp_macro.py` - G마켓/옥션 ERP 주문번호 기준 변경
- `utils/macros/ERP/zigzag_erp_macro.py` - 지그재그 ERP 주문번호 기준 변경

**Happojang Macros (5 files)**

- `utils/macros/happojang/ali_merge_packaging.py` - sale_cnt 합산 적용
- `utils/macros/happojang/brandy_merge_packaging.py` - sale_cnt 합산 적용
- `utils/macros/happojang/etc_site_merge_packaging.py` - sale_cnt 합산 적용
- `utils/macros/happojang/gok_merge_packaging.py` - sale_cnt 합산 적용
- `utils/macros/happojang/zigzag_merge_packaging.py` - sale_cnt 합산 적용

**Utilities (3 files)**

- `utils/macros/ERP/utils.py` - 주문번호 기준 평균 처리 함수 개선
- `utils/macros/happojang/utils.py` - **신규 생성**: sale_cnt 합산 유틸리티
- `utils/mappings/down_form_order_mapper.py` - 분수 계산 로직 제거

**Total**: 15 files modified, 1 file added (+100 lines, -98 lines)