### PR TITLE
Fix: 상품등록 - #315 product get all to get products all

### DIFF
--- a/services/product_registration/product_integrated_service.py
+++ b/services/product_registration/product_integrated_service.py
@@ -61,7 +61,7 @@ class ProductCodeIntegratedService:
             product_mycategory_repo = ProductMyCategoryRepository(session)
             
             # 1. Fetch all registration data
-            registration_data_list: List[ProductRegistrationRawData] = await self.reg_repo.get_all(limit=limit, offset=offset)
+            registration_data_list: List[ProductRegistrationRawData] = await self.reg_repo.get_products_all(limit=limit)
             
             # 모든 데이터를 상세히 로깅
             logger.info(f"registration_data_list count: {len(registration_data_list)}")

--- a/services/product_registration/product_registration_service.py
+++ b/services/product_registration/product_registration_service.py
@@ -308,7 +308,7 @@ class ProductRegistrationService:
             List[ProductRegistrationResponseDto]: 조회된 데이터 리스트
         """
         try:
-            data_list = await self.repository.get_all(limit, offset)
+            data_list = await self.repository.get_products_all(limit)
             return [ProductRegistrationResponseDto.from_orm(data) for data in data_list]
             
         except Exception as e:


### PR DESCRIPTION
# fix: Update product retrieval method calls across services

## 🎯 개요

Repository 계층의 메서드명 변경에 따라 ProductCodeIntegratedService와 ProductRegistrationService에서 호출하는 메서드를 업데이트했습니다. `get_all()` 메서드를 `get_products_all()`로 변경하고, offset 파라미터를 제거하여 API 일관성을 개선했습니다.

## 🔄 변경 사항

<details> <summary><strong>🔸 Repository 계층 개선</strong></summary>

### ProductCodeIntegratedService

- `self.reg_repo.get_all(limit=limit, offset=offset)` → `self.reg_repo.get_products_all(limit=limit)`
- offset 파라미터 제거로 페이징 로직 단순화

### ProductRegistrationService

- `self.repository.get_all(limit, offset)` → `self.repository.get_products_all(limit)`
- 동일한 메서드명 통일화 적용

</details>

## 🆕 주요 신규 및 변경 기능

- **메서드명 표준화**: Repository 계층의 제품 조회 메서드명을 `get_products_all()`로 통일
- **파라미터 최적화**: offset 파라미터 제거로 인한 호출 인터페이스 단순화
- **API 일관성 향상**: 두 서비스에서 동일한 메서드 시그니처 사용

## 🏗️ 아키텍처 개선사항

- Repository 패턴의 인터페이스 일관성 확보
- 서비스 계층에서 Repository 메서드 호출 방식 표준화
- 코드 가독성 및 유지보수성 향상

## 🔄 처리 플로우

1. ProductCodeIntegratedService에서 제품 등록 데이터 조회 시 새로운 메서드 사용
2. ProductRegistrationService에서 제품 데이터 조회 시 동일한 메서드 사용
3. 두 서비스 모두 limit 파라미터만 사용하여 데이터 조회

### 🎯 관련 이슈

- **Close**: #315  

## 🔍 데이터 스키마 변경

- 데이터 스키마 변경 없음
- Repository 메서드 시그니처 변경만 적용

## 🏆 기대 효과

- **코드 일관성**: 전체 서비스에서 동일한 Repository 메서드 사용
- **유지보수성**: 메서드명 표준화로 개발자 혼란 감소
- **성능**: offset 파라미터 제거로 단순한 페이징 로직 적용

## 📂 주요 변경 파일

- `services/product_registration/product_integrated_service.py` (1줄 수정)
- `services/product_registration/product_registration_service.py` (1줄 수정)

**변경된 파일**: 2개  
**추가된 줄**: 2줄  
**삭제된 줄**: 2줄