### PR TITLE
Fix:주문관리 - Excel macro_run 데이터 와 DB_to_DB macro_run 데이터 맵핑개선.

### DIFF
--- a/utils/macros/ERP/utils.py
+++ b/utils/macros/ERP/utils.py
@@ -79,24 +79,24 @@ def add_island_delivery(df: pd.DataFrame):
     """
     logger.info(f"[START]add_island_delivery")
     island_dict = [
-        {"site_name": "GSSHOP", "fid_dsp": "GSSHOP", "cost": 3000, "add_dsp": None},
-        {"site_name": "텐바이텐", "fid_dsp": "텐바이텐", "cost": 3000,
+        {"site_name": "GSSHOP", "fld_dsp": "GSSHOP", "cost": 3000, "add_dsp": None},
+        {"site_name": "텐바이텐", "fld_dsp": "텐바이텐", "cost": 3000,
          "add_dsp": "[3000원 연락해야함, 어드민 조회필요(외부몰/자체몰)]"},
-        {"site_name": "쿠팡", "fid_dsp": "쿠팡", "cost": 3000, "add_dsp": None},
-        {"site_name": "무신사", "fid_dsp": "무신사", "cost": 3000, "add_dsp": None},
-        {"site_name": "NS홈쇼핑", "fid_dsp": "NS홈쇼핑", "cost": 3000, "add_dsp": None},
-        {"site_name": "CJ온스타일", "fid_dsp": "CJ온스타일", "cost": 3000, "add_dsp": None},
-        {"site_name": "오늘의집", "fid_dsp": "오늘의집", "cost": 3000, "add_dsp": None},
-        {"site_name": "브랜디", "fid_dsp": "브랜디",
+        {"site_name": "쿠팡", "fld_dsp": "쿠팡", "cost": 3000, "add_dsp": None},
+        {"site_name": "무신사", "fld_dsp": "무신사", "cost": 3000, "add_dsp": None},
+        {"site_name": "NS홈쇼핑", "fld_dsp": "NS홈쇼핑", "cost": 3000, "add_dsp": None},
+        {"site_name": "CJ온스타일", "fld_dsp": "CJ온스타일", "cost": 3000, "add_dsp": None},
+        {"site_name": "오늘의집", "fld_dsp": "오늘의집", "cost": 3000, "add_dsp": None},
+        {"site_name": "브랜디", "fld_dsp": "브랜디",
             "cost": 3000, "add_dsp": "[3000원 연락해야함]"},
-        {"site_name": "에이블리", "fid_dsp": "에이블리", "cost": 3000, "add_dsp": None},
-        {"site_name": "보리보리", "fid_dsp": "보리보리",
+        {"site_name": "에이블리", "fld_dsp": "에이블리", "cost": 3000, "add_dsp": None},
+        {"site_name": "보리보리", "fld_dsp": "보리보리",
             "cost": 3000, "add_dsp": "[3000원 연락해야함]"},
-        {"site_name": "지그재그", "fid_dsp": "지그재그", "cost": 3000, "add_dsp": None},
-        {"site_name": "카카오톡선물하기", "fid_dsp": "카카오선물하기",
+        {"site_name": "지그재그", "fld_dsp": "지그재그", "cost": 3000, "add_dsp": None},
+        {"site_name": "카카오톡선물하기", "fld_dsp": "카카오선물하기",
             "cost": 3000, "add_dsp": "[3000원 연락해야함]"},
-        {"site_name": "11번가", "fid_dsp": "11번가", "cost": 5000, "add_dsp": None},
-        {"site_name": "홈&쇼핑", "fid_dsp": "홈&쇼핑",
+        {"site_name": "11번가", "fld_dsp": "11번가", "cost": 5000, "add_dsp": None},
+        {"site_name": "홈&쇼핑", "fld_dsp": "홈&쇼핑",
             "cost": 3000, "add_dsp": "[3000원 연락해야함]"},
     ]
 
@@ -112,8 +112,8 @@ def add_island_delivery(df: pd.DataFrame):
 
     for island_info in island_dict:
         # 해당 사이트의 제주도 배송 데이터 필터링
-        site_mask = jeju_data['fid_dsp'].fillna('').str.contains(
-            island_info['fid_dsp'], case=False, na=False
+        site_mask = jeju_data['fld_dsp'].fillna('').str.contains(
+            island_info['fld_dsp'], case=False, na=False
         )
         target_indices = jeju_data[site_mask].index
 
@@ -144,14 +144,27 @@ def format_phone_number(df: pd.DataFrame):
     """
     전화번호 포맷팅
     """
-    receive_tel = df['receive_tel'].fillna('').str.replace('-', '')
-    receive_cel = df['receive_cel'].fillna('').str.replace('-', '')
-    if len(receive_tel) == 11 and receive_tel.startswith('010') and receive_tel.isdigit():
-        df.loc[receive_tel,
-               'receive_tel'] = f"{receive_tel[:3]}-{receive_tel[3:7]}-{receive_tel[7:]}"
-    if len(receive_cel) == 11 and receive_cel.startswith('010') and receive_cel.isdigit():
-        df.loc[receive_cel,
-               'receive_cel'] = f"{receive_cel[:3]}-{receive_cel[3:7]}-{receive_cel[7:]}"
+    df['receive_tel'] = df['receive_tel'].fillna(
+        '').astype(str).str.replace('-', '')
+    df['receive_cel'] = df['receive_cel'].fillna(
+        '').astype(str).str.replace('-', '')
+
+    # 조건에 맞는 행들만 포맷팅
+    tel_mask = (df['receive_tel'].str.len() == 11) & (
+        df['receive_tel'].str.startswith('010')) & (df['receive_tel'].str.isdigit())
+
+    cel_mask = (df['receive_cel'].str.len() == 11) & (
+        df['receive_cel'].str.startswith('010')) & (df['receive_cel'].str.isdigit())
+
+    # 포맷팅 적용
+    df.loc[tel_mask, 'receive_tel'] = df.loc[tel_mask, 'receive_tel'].apply(
+        lambda x: f"{x[:3]}-{x[3:7]}-{x[7:]}"
+    )
+
+    df.loc[cel_mask, 'receive_cel'] = df.loc[cel_mask, 'receive_cel'].apply(
+        lambda x: f"{x[:3]}-{x[3:7]}-{x[7:]}"
+    )
+
     return df
 
 
@@ -174,15 +187,18 @@ def star_average_process(df: pd.DataFrame):
     if len(valid_delivery_df) > 0:
         group_sizes = valid_delivery_df.groupby('star_avg').size()
         groups_with_multiple = group_sizes[group_sizes >= 2].index
-        
+
         if len(groups_with_multiple) > 0:
-            avg_delivery = valid_delivery_df[valid_delivery_df['star_avg'].isin(groups_with_multiple)].groupby('star_avg')['delv_cost'].mean()
-            
+            avg_delivery = valid_delivery_df[valid_delivery_df['star_avg'].isin(
+                groups_with_multiple)].groupby('star_avg')['delv_cost'].mean()
+
             # 평균 배송비 적용
-            df.loc[df['star_avg'].isin(avg_delivery.index), 'delv_cost'] = df.loc[df['star_avg'].isin(avg_delivery.index), 'star_avg'].map(avg_delivery)
-            
-            logger.info(f"스타배송 평균 배송비 적용 완료: {len(avg_delivery)}개 그룹 (2개 이상인 그룹만)")
-    
+            df.loc[df['star_avg'].isin(avg_delivery.index), 'delv_cost'] = df.loc[df['star_avg'].isin(
+                avg_delivery.index), 'star_avg'].map(avg_delivery)
+
+            logger.info(
+                f"스타배송 평균 배송비 적용 완료: {len(avg_delivery)}개 그룹 (2개 이상인 그룹만)")
+
     # 임시 컬럼 제거
     df = df.drop('star_avg', axis=1)
     return df

--- a/utils/macros/happojang/bundle_utils_v3.py
+++ b/utils/macros/happojang/bundle_utils_v3.py
@@ -14,19 +14,19 @@ class BundleUtilsV3:
             self.df['receive_addr'] + self.df['receive_name']
 
         all_columns = {
-            'order_id': 'min',  # 주문 번호
-            'item_name': ' + '.join,  # 제품명
+            'order_id': 'max',  # 주문 번호
+            'item_name': self.reversed_join(' + '),  # 제품명
             'service_fee': 'max',  # 서비스이용료
             'pay_cost': 'sum',  # 금액[배송비미포함]
             'delv_cost': 'max',
-            'idx': lambda x: '/'.join(filter(None, x)),  # 사방넷주문번호
-            'product_name': lambda x: ' / '.join(filter(None, x)),  # 수집상품명
-            'mall_product_id': lambda x: '/'.join(filter(None, x)),  # 상품번호
-            'sku_value': lambda x: '/'.join(filter(None, x)),  # 수집옵션
-            'sale_cnt': lambda x: str(sum(int(val) for val in x if val is not None)),  # 수량
+            'idx': self.reversed_join('/'),  # 사방넷주문번호
+            'product_name': self.reversed_join(' / '),  # 수집상품명
+            'mall_product_id': self.reversed_join('/'),  # 상품번호
+            'sku_value': self.reversed_join('/'),  # 수집옵션
+            'sale_cnt': self.sum_to_str(),  # 수량
             'expected_payout': 'max',  # 정산예정금액
-            'delv_msg': lambda x: '/'.join(filter(None, x)),  # 배송메시지
-            'etc_cost': lambda x: str(sum(int(val) for val in x if val is not None)),  # 금액(이미 ERP 매크로를 통해 계산된 값)
+            'delv_msg': self.reversed_join('/'),  # 배송메시지
+            'etc_cost': self.sum_to_str(),  # 금액(이미 ERP 매크로를 통해 계산된 값)
 
             # 나머지 컬럼
             'seq': 'first',
@@ -55,3 +55,11 @@ class BundleUtilsV3:
         run_bundle_macro_data = self.df.to_dict(orient='records')
         logger.info(f"[END]run_bundle_macro_data")
         return run_bundle_macro_data
+
+    def reversed_join(self, target_str: str) -> str:
+        """역순으로 join"""
+        return lambda x: target_str.join(filter(None, x[::-1]))
+
+    def sum_to_str(self) -> str:
+        """정수 합계 문자열로 반환"""
+        return lambda x: str(sum(int(val) for val in x if val is not None))


### PR DESCRIPTION
## 🎯 개요
Excel 파일 macro_run 데이터와 DB_to_DB macro_run 데이터를 일치 시켰습니다. 
추후 DB_to_DB macro_run 데이터를 Excel 파일로 만들어 한번 더 확인이 필요 합니다.

## 🔄 변경 사항

<details>
<summary><strong>🔸 ERP Utils 개선</strong></summary>

- **제주도 배송 필드명 수정**: `fid_dsp` → `fld_dsp`로 통일하여 데이터 매핑 오류 해결
- **전화번호 포맷팅 로직 개선**: 조건부 포맷팅으로 성능 향상 및 안정성 증대

</details>

<details>
<summary><strong>🔸 Bundle Utils V3 리팩토링</strong></summary>

- **집계 로직 개선**: `order_id`를 `min`에서 `max`로 변경하여 최신 주문번호 우선 처리
- **유틸리티 메서드 도입**: `reversed_join()`, `sum_to_str()` 메서드로 코드 재사용성 향상

</details>

## 🆕 주요 신규 * 변경 기능

### 1. 제주도 배송 필드명 통일
- 모든 사이트의 제주도 배송 정보에서 `fld_dsp` 필드명으로 통일
- 데이터 매핑 오류로 인한 배송비 계산 실패 방지

### 2. 전화번호 포맷팅 최적화
- 조건부 포맷팅으로 불필요한 연산 제거
- 010으로 시작하는 11자리 숫자만 하이픈 추가

## 🏗️ 아키텍처 개선사항

- **유틸리티 메서드 분리**: 공통 로직을 별도 메서드로 추출하여 재사용성 향상

## 🔄 처리 플로우

1. **데이터 전처리**: 제주도 배송 정보 필드명 통일
2. **배송비 계산**: 스타배송 평균 배송비 자동 계산
3. **전화번호 포맷팅**: 조건에 맞는 전화번호만 하이픈 추가


## 📂 주요 변경 파일

| 파일 경로 | 변경 유형 | 주요 내용 |
|-----------|-----------|-----------|
| `utils/macros/ERP/utils.py` | 수정 | 제주도 배송 필드명 통일, 전화번호 포맷팅 최적화, 스타배송 로직 개선 |
| `utils/macros/happojang/bundle_utils_v3.py` | 수정 | 집계 로직 개선, 유틸리티 메서드 도입, 데이터 처리 순서 최적화 |