### PR TITLE
Fix: 주문관리 - issue_366 쇼핑몰 이름 관련 data handling mall_id -> fld_dsp 변경

### DIFF
--- a/schemas/down_form_orders/down_form_order_dto.py
+++ b/schemas/down_form_orders/down_form_order_dto.py
@@ -120,7 +120,7 @@ class DownFormOrdersInvoiceNoUpdateDto(BaseDTO):
 
 class DownFormOrdersFromReceiveOrdersDto(BaseDTO):
     success: Optional[bool] = Field(None, description="성공 여부")
-    mall_id: Optional[str] = Field(None, description="쇼핑몰 아이디")
+    fld_dsp: Optional[str] = Field(None, description="사이트 명")
     dpartner_id: Optional[str] = Field(None, description="배송구분(일반배송, 스타배송)")
     processed_count: Optional[int] = Field(None, description="처리된 데이터 수")
     saved_count: Optional[int] = Field(None, description="저장된 데이터 수")

--- a/schemas/receive_orders/request/receive_orders_request.py
+++ b/schemas/receive_orders/request/receive_orders_request.py
@@ -159,7 +159,7 @@ class ReceiveOrdersFillterRequest(BaseDateRangeRequest):
     날짜/주문상태 Optional 요청 객체
     """
     # 부모 클래스가 이미 모든 필드를 Optional로 제공하므로 그대로 사용
-    mall_id: Optional[str] = Field(None, description="몰 ID")
+    fld_dsp: Optional[str] = Field(None, description="사이트 명")
     order_status: Optional[OrderStatusLabel] = Field(None, description="주문 상태")
 
     @field_validator("order_status")
@@ -178,7 +178,7 @@ class ReceiveOrdersFillterRequest(BaseDateRangeRequest):
                 "date_from": "2025-06-02",
                 "date_to": "2025-06-06",
                 "order_status": "출고완료",
-                "mall_id": "ESM지마켓"
+                "fld_dsp": "G마켓2.0"
             }
         }
     )
@@ -193,7 +193,7 @@ class ReceiveOrdersToDownFormOrdersFillterRequst(ReceiveOrdersFillterRequest):
                 "date_from": "2025-06-02",
                 "date_to": "2025-06-06",
                 "order_status": "출고완료",
-                "mall_id": "ESM지마켓",
+                "fld_dsp": "G마켓2.0",
                 "dpartner_id": "오케이마트"
             }
         }

--- a/services/usecase/data_processing_usecase.py
+++ b/services/usecase/data_processing_usecase.py
@@ -236,7 +236,7 @@ class DataProcessingUsecase:
             f"[START] save_down_form_order_from_receive_orders_by_filters_v2 filters: {filters}")
 
         # 몰 아이디, 배송구분 추출
-        mall_id = filters.get('mall_id')
+        fld_dsp = filters.get('fld_dsp')
         dpartner_id = filters.get('dpartner_id')
 
         # (임시 주석처리)
@@ -263,14 +263,13 @@ class DataProcessingUsecase:
 
         # 4. template_code 설정[ERP, 합포장]
         template_code_mapping = {
-            'ESM옥션': ('gmarket_erp', 'gmarket_bundle'),
-            'ESM지마켓': ('gmarket_erp', 'gmarket_bundle'),
+            '옥션2.0': ('gmarket_erp', 'gmarket_bundle'),
+            'G마켓2.0': ('gmarket_erp', 'gmarket_bundle'),
             '브랜디': ('brandi_erp', 'basic_bundle'),
-            '지그재그': ('zigzag_erp', 'zigzag_bundle'),
-            '기타사이트': ('basic_erp', 'basic_bundle')
+            '지그재그': ('zigzag_erp', 'zigzag_bundle')
         }
         erp_template_code, bundle_template_code = template_code_mapping.get(
-            mall_id, ('basic_erp', 'basic_bundle'))
+            fld_dsp, ('basic_erp', 'basic_bundle'))
 
         is_star = False
         # 5. 배송구분(일반배송, 스타배송) 설정
@@ -293,7 +292,7 @@ class DataProcessingUsecase:
 
         return DownFormOrdersFromReceiveOrdersDto(
             success=True,
-            mall_id=mall_id,
+            fld_dsp=fld_dsp,
             dpartner_id=dpartner_id,
             processed_count=len(receive_orders),
             saved_count=saved_count,


### PR DESCRIPTION
## 📋 프로세스 시각화

```mermaid
graph TD
    A[fld_dsp 필드 사용] --> B[fld_dsp  필터링 조건으로 쿼리 ]
    B --> C[receive_data 반환]
```

## 🎯 개요

쇼핑몰 이름 관련해서 data handling에서 발생하는 필드명을 `mall_id`에서 `fld_dsp`로 변경했습니다. 쇼핑몰 아이디가 아닌 사이트 이름으로 추적가능하게 변경했습니다.

## 🔄 변경 사항

<details>
<summary><strong>🔸Repository 계층 개선</strong></summary>

- **ReceiveOrdersRepository**: `get_receive_orders_by_filters` 메서드에서 `fld_dsp` 필드 기반 필터링 로직 구현
- 필터 조건에 `fld_dsp` 필드 추가하여 사이트별 데이터 조회 기능 강화

</details>

<details>
<summary><strong>🔸 Service 계층 개선</strong></summary>

- **DataProcessingUsecase**: `save_down_form_order_from_receive_orders_by_filters_v2` 메서드에서 `fld_dsp` 필터 처리 로직 개선
- 템플릿 코드 매핑에서 `fld_dsp` 값에 따른 ERP/합포장 템플릿 선택 로직 최적화

</details>

<details>
<summary><strong>🔸 Schema 계층 개선</strong></summary>

- **DownFormOrderDto**: `fld_dsp` 필드 추가로 사이트 정보 관리 개선
- **ReceiveOrdersFillterRequest**: `fld_dsp` 필드를 Optional 필드로 추가하여 유연한 필터링 지원
- **ReceiveOrdersToDownFormOrdersFillterRequst**: 상속받은 `fld_dsp` 필드 활용

</details>

## 🆕 주요 신규/변경기능

### 1. **일관된 필드명 사용**
- `mall_id` → `fld_dsp`로 통일하여 데이터베이스 스키마와 일치
- API 요청/응답에서 동일한 필드명 사용으로 혼란 방지

### 2. **향상된 필터링 시스템**
- 사이트별 데이터 필터링 기능 강화
- `fld_dsp` 필드를 통한 정확한 쇼핑몰 구분

## 🔄 처리 플로우

1. **API 요청**: `ReceiveOrdersFillterRequest`에서 `fld_dsp` 필터 설정
2. **Service 처리**: `DataProcessingUsecase`에서 `fld_dsp` 기반 템플릿 선택
3. **Repository 조회**: `ReceiveOrdersRepository`에서 `fld_dsp` 조건으로 데이터 필터링
4. **데이터 변환**: 선택된 템플릿에 따라 ERP/합포장 데이터 생성
5. **결과 반환**: 처리된 데이터와 통계 정보 반환

## 🎯 관련 이슈

- #366 


## 🔍 데이터 스키마 변경

### **변경된 필드**
- `mall_id` → `fld_dsp` (사이트 정보 필드)
- 기존 데이터베이스의 `fld_dsp` 컬럼과 일치하도록 API 스키마 수정

## 📂 주요 변경 파일

### **Schema Layer**
- `schemas/down_form_orders/down_form_order_dto.py` - `fld_dsp` 필드 추가
- `schemas/receive_orders/request/receive_orders_request.py` - `fld_dsp` 필터 필드 추가

### **Service Layer**
- `services/usecase/data_processing_usecase.py` - `fld_dsp` 기반 템플릿 선택 로직

### **Repository Layer**
- `repository/receive_orders_repository.py` - `fld_dsp` 필터링 조건 추가

## 🔌 Frontend 연동 가이드

### **API 요청 예시**
```json
{
  "date_from": "2025-01-01",
  "date_to": "2025-01-31",
  "order_status": "출고완료",
  "fld_dsp": "G마켓2.0",
  "dpartner_id": "일반배송"
}
```

### **응답 데이터 구조**
```json
{
  "success": true,
  "fld_dsp": "G마켓2.0",
  "dpartner_id": "일반배송",
  "processed_count": 150,
  "saved_count": 300,
  "message": "Successfully processed 150 records and total saved 300 records..."
}
```

### **주요 변경사항**
- **필드명 변경**: `mall_id` → `fld_dsp`로 통일