### PR TITLE
Issue: 주문관리 - issue376번 2025.09.25일 macro_run 이슈 해결.

### DIFF
--- a/utils/macros/happojang/utils.py
+++ b/utils/macros/happojang/utils.py
@@ -38,7 +38,11 @@ def process_slash_separated_columns(ws, columns: list, start_row: int = 2) -> No
     for col in columns:
         for row in range(start_row, max_row + 1):
             cell = ws[f'{col}{row}']
+            cell_value = cell.value
             if cell.value:
+                # int, float 타입 문자열로 변환
+                if isinstance(cell_value, (int, float)):
+                    cell_value = str(int(cell.value))
                 # '/' 구분자 합산 처리
-                processed_value = sum_slash_separated_values(str(int(cell.value)))
+                processed_value = sum_slash_separated_values(cell_value)
                 cell.value = processed_value


### PR DESCRIPTION
## 📋 프로세스 시각화
```mermaid
graph TD
    A[Excel 파일 업로드] --> B[파일명 확인]
    B --> C[파일명 구조에 상관없이 매크로 매칭]
```

## 🎯 개요
 정해진 파일명 순서에 따라 `site_type`, `usage_type`, `sub_site`를 적용했지만 순서가 변경된 경우 error가 발생했습니다. 정해진 순서와 상관없이 `site_type`, `usage_type`, `sub_site`찾도록 변경했습니다. 
특정 합포장 로직에서 `/`로 인해 이슈가 발생했으며 특정 조건문을 통해 해결했습니다.


## 🔄 변경 사항

<details>
<summary><strong>🔸 매크로 처리 로직 개선</strong></summary>

- **파일명 파싱 기능 개선** : 정해진 순서에 상관없이 파싱적용 
- **데이터 처리 유틸리티 추가**: `/` 구분자 합산 처리 기능 구현

</details>

## 🆕 주요 신규 * 변경 기능

### 1. 파일명 파싱 기능
- **`parse_filename`** : 파일명 구조에 상관없이 `site_type`, `usage_type`, `sub_site`구분


### 2. `/` 구분자 합산 처리 기능
- **`sum_slash_separated_values`**: 슬래시로 구분된 숫자들의 합산 처리


## 🔄 처리 플로우

### 파일명 구분 플로우
1. **Excel 파일 로드** 
2. **파일명 구분** -> parse_filename
- site_type
- usage_type
- sub_site
3. **template_code 매칭**

### `/` 구분자 처리 플로우
1. **컬럼 식별** → 처리할 컬럼 리스트 확인
2. **값 추출** → 각 셀의 값 확인
3. **슬래시 분리** → `/` 구분자로 분리
5. **숫자 합산** → 각 부분의 숫자 합계 계산
6. **결과 적용** → 처리된 값을 셀에 저장

## 🎯 관련 이슈

- #376

## 📂 주요 변경 파일

- `services/usecase/data_processing_usecase.py` - 데이터 처리 유스케이스
- `utils/macros/happojang/utils.py` -`/` 구분자 합산 처리 유틸리티
